### PR TITLE
upcasing the postal code to further normalize it

### DIFF
--- a/lib/attribute_normalizer/extras/version.rb
+++ b/lib/attribute_normalizer/extras/version.rb
@@ -1,5 +1,5 @@
 module AttributeNormalizer
   module Extras
-    VERSION = "0.1.1"
+    VERSION = "0.0.2"
   end
 end

--- a/lib/attribute_normalizer/extras/version.rb
+++ b/lib/attribute_normalizer/extras/version.rb
@@ -1,5 +1,5 @@
 module AttributeNormalizer
   module Extras
-    VERSION = "0.0.1"
+    VERSION = "0.1.1"
   end
 end

--- a/lib/attribute_normalizer/normalizers/postal_code_normalizer.rb
+++ b/lib/attribute_normalizer/normalizers/postal_code_normalizer.rb
@@ -2,7 +2,7 @@ module AttributeNormalizer
   module Normalizers
     module PostalCodeNormalizer
       def self.normalize(value, options)
-        GsubNormalizer.normalize value, pattern: /\W+|_/, replacement: ''
+        GsubNormalizer.normalize value.upcase, pattern: /\W+|_/, replacement: ''
       end
     end
   end

--- a/spec/models/postal_code_normalizer_spec.rb
+++ b/spec/models/postal_code_normalizer_spec.rb
@@ -16,7 +16,7 @@ describe AttributeNormalizer::Normalizers::PostalCodeNormalizer do
     end
 
     it 'upcases lowercase text' do
-      expect(subject.normalize "t6h1v2" {}).to eq "T6H1V2"
+      expect(subject.normalize "t6h1v2", {}).to eq "T6H1V2"
     end
 
   end

--- a/spec/models/postal_code_normalizer_spec.rb
+++ b/spec/models/postal_code_normalizer_spec.rb
@@ -14,6 +14,11 @@ describe AttributeNormalizer::Normalizers::PostalCodeNormalizer do
     it 'removes whitespace' do
       expect(subject.normalize " T1T 1T1 ", {}).to eq "T1T1T1"
     end
+
+    it 'upcases lowercase text' do
+      expect(subject.normalize "t6h1v2" {}).to eq "T6H1V2"
+    end
+
   end
 
 end


### PR DESCRIPTION
from https://github.com/amaabca/api/pull/182

"can you move this to https://github.com/amaabca/attribute_normalizer-extras/blob/master/lib/attribute_normalizer/normalizers/postal_code_normalizer.rb#L4 as upcase ? it won't need !"

-Bumped version number - see http://semver.org for reasoning
-Added test
